### PR TITLE
feat: handle arrays only using pointers

### DIFF
--- a/a.out.dSYM/Contents/Info.plist
+++ b/a.out.dSYM/Contents/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>English</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.apple.xcode.dsym.a.out</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundlePackageType</key>
+		<string>dSYM</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0</string>
+		<key>CFBundleVersion</key>
+		<string>1</string>
+	</dict>
+</plist>

--- a/ast/ast.cpp
+++ b/ast/ast.cpp
@@ -161,10 +161,7 @@ Value *ArrayAST::codeGen() {
   mBuilder.CreateStore(castedMalloc, elOne);
   mBuilder.CreateStore(ConstantInt::get(mContext, APInt(32, arrayLength)), elTwo);
 
-  std::cout << "current depth: " << arrayDepths[name] << std::endl;
   arrayDepths[name] = depth;
-  std::cout << "next depth: " << arrayDepths[name] << std::endl;
-
   namedValues[name] = allocStruct;
   return mBuilder.CreateLoad(allocStruct, "init_alloca_load");
 }
@@ -172,25 +169,20 @@ Value *ArrayAST::codeGen() {
 Value *ArrayElementAST::codeGen() {
   auto *structAlloca = namedValues[name];
   auto depth = arrayDepths[name];
-  std::cout << "Depth: " << depth << std::endl;
 
   // {{...}}
   auto *alloca = mBuilder.CreateGEP(structAlloca, GEP(0)); // we only want the first element because that is the array pointer
   Value *newArray = mBuilder.CreateLoad(alloca, "load_array_ptr");
-  newArray->print(errs());
 
   while (depth > 1) {
     // {...}
-    std::cout << "starting \n";
     newArray = mBuilder.CreateGEP(newArray, GEP(0));
     newArray = mBuilder.CreateLoad(newArray);
-    newArray->print(errs());
     depth--;
   }
 
   // double*
   newArray = mBuilder.CreateGEP(newArray, PGEP(0)); 
-  newArray->print(errs());
 
   if (returnPtr) return newArray;
   return mBuilder.CreateLoad(newArray, "final_element"); 

--- a/ast/ast.h
+++ b/ast/ast.h
@@ -26,6 +26,7 @@ static LLVMContext mContext;
 static IRBuilder<> mBuilder(mContext);
 static std::unique_ptr<Module> mModule = make_unique<Module>("Super", mContext);
 static std::map<std::string, AllocaInst *> namedValues;
+static std::map<std::string, int> arrayDepths;
 static Module *M = mModule.get();
 static Type *dType = Type::getDoubleTy(mContext);
 static Type *i32 = IntegerType::get(mContext, 32);
@@ -66,7 +67,8 @@ class ArrayAST: public AST {
   std::string name;
 
   public:
-  ArrayAST(std::vector<std::unique_ptr<AST>> numbers, std::string name): numbers(std::move(numbers)), name(name) { }
+  ArrayAST(std::vector<std::unique_ptr<AST>> numbers, std::string name): 
+    numbers(std::move(numbers)), name(name) { }
   llvm::Value *codeGen() override;
 };
 

--- a/ast/ast.h
+++ b/ast/ast.h
@@ -28,6 +28,8 @@ static std::unique_ptr<Module> mModule = make_unique<Module>("Super", mContext);
 static std::map<std::string, AllocaInst *> namedValues;
 static Module *M = mModule.get();
 static Type *dType = Type::getDoubleTy(mContext);
+static Type *i32 = IntegerType::get(mContext, 32);
+static Type *pi8 = PointerType::getUnqual(IntegerType::get(mContext, 8));
 static Type *aType = ArrayType::get(dType, 4); // TODO: implemnt x length
 static Value *nullValue = Constant::getNullValue(dType);
 
@@ -41,6 +43,14 @@ class BaseFuncAST {
   public:
     virtual ~BaseFuncAST() { }
     virtual llvm::Function *codeGen() = 0;
+};
+
+class IntAST: public AST {
+  int val;
+
+  public:
+  IntAST(int val): val(val) { }
+  llvm::Value *codeGen() override;
 };
 
 class NumberAST: public AST {

--- a/ast/ast.h
+++ b/ast/ast.h
@@ -64,9 +64,9 @@ class NumberAST: public AST {
 
 class ArrayAST: public AST {
   std::vector<std::unique_ptr<AST>> numbers;
-  std::string name;
 
   public:
+  std::string name;
   ArrayAST(std::vector<std::unique_ptr<AST>> numbers, std::string name): 
     numbers(std::move(numbers)), name(name) { }
   llvm::Value *codeGen() override;

--- a/ast/ast.h
+++ b/ast/ast.h
@@ -71,12 +71,13 @@ class ArrayAST: public AST {
 };
 
 class ArrayElementAST: public AST {
+  bool returnPtr;
   std::string name;
   std::vector<std::unique_ptr<AST>> indexs;
 
   public:
-  ArrayElementAST(std::string name, std::vector<std::unique_ptr<AST>> indexs): 
-    name(name), indexs(std::move(indexs)) { }
+  ArrayElementAST(std::string name, std::vector<std::unique_ptr<AST>> indexs, bool returnPtr = false): 
+    name(name), returnPtr(returnPtr), indexs(std::move(indexs)) { }
   Value *codeGen() override;
 };
 

--- a/built.dSYM/Contents/Info.plist
+++ b/built.dSYM/Contents/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>English</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.apple.xcode.dsym.built</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundlePackageType</key>
+		<string>dSYM</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0</string>
+		<key>CFBundleVersion</key>
+		<string>1</string>
+	</dict>
+</plist>

--- a/main.cpp
+++ b/main.cpp
@@ -57,6 +57,20 @@ static std::string handleExtern(Parser * &p) {
   return IR;
 }
 
+static std::string externMalloc() {
+  std::string IR;
+  raw_string_ostream OS(IR);
+
+  std::vector<std::pair<std::string, llvm::Type *>> argNames;
+  argNames.push_back(std::make_pair("x", i32));
+
+  auto *mallocProto = new PrototypeAST("malloc", std::move(argNames), pi8);
+  if (auto *etrnIR = mallocProto->codeGen())
+    etrnIR->print(OS);
+
+  return IR;
+}
+
 static std::string mainLoop(Parser * &p) {
   std::string IR;
 
@@ -93,7 +107,9 @@ static std::string run(char* argv[]) {
 
   p->getNextToken();
 
-  std::string IR = mainLoop(p);
+  std::string IR = externMalloc();
+
+  IR += mainLoop(p);
 
   IR += loadTopLevel(p);
 

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<AST> Parser::ParseArray(std::string name) {
   getNextToken(); // Move past `[`
   std::vector<std::unique_ptr<AST>> numbers;
 
-  while (currentToken != ']')
+  while (currentToken != ']') 
     numbers.push_back(ParseExpression());
   
   getNextToken(); // Move over `]`

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -198,7 +198,13 @@ std::unique_ptr<PrototypeAST> Parser::ParsePrototype() {
     while (currentToken != ')' /*== Token::token_id*/) {
       std::string argName = mLexer->identifier;
       getNextToken(); // Move past id
-      argNames.push_back(std::make_pair(argName, ParsePrimary()->codeGen()->getType()));
+
+      auto argAST = ParsePrimary();
+      if (auto *argAsArrayAST = dynamic_cast<ArrayAST *>(argAST.get())) {
+        argAsArrayAST->name = argName;
+        argNames.push_back(std::make_pair(argName, argAsArrayAST->codeGen()->getType()));
+      } else
+        argNames.push_back(std::make_pair(argName, argAST->codeGen()->getType()));
     }
 
     if (currentToken != ')') return LogErrorPlain("Expected to end with `)` (Prototype)");


### PR DESCRIPTION
Arrays are now only handled as pointers. This allows for multidimensional arrays to be passed to functions and returned. It also increases performance and flexibility of the language. 

### Details:
* `malloc` is used to allocate arrays
* arrays are stored as pointers to their type (currently that is only `double*`)
* arrays are wrapped in structs that provide metadata about them (currently this is only their length)
* see lines `119-175` in `ast/ast.cpp` for more details on implementation and formatting